### PR TITLE
Add picture URL to LinkedIn user info endpoint default fields

### DIFF
--- a/Owin.Security.Providers/LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/Owin.Security.Providers/LinkedIn/LinkedInAuthenticationHandler.cs
@@ -17,7 +17,7 @@ namespace Owin.Security.Providers.LinkedIn
     {
         private const string XmlSchemaString = "http://www.w3.org/2001/XMLSchema#string";
         private const string TokenEndpoint = "https://www.linkedin.com/uas/oauth2/accessToken";
-        private const string UserInfoEndpoint = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,email-address,public-profile-url)";
+        private const string UserInfoEndpoint = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,email-address,public-profile-url,picture-url)";
 
         private readonly ILogger logger;
         private readonly HttpClient httpClient;


### PR DESCRIPTION
Extended the list of fields included on the LinkedIn basic profile scope
endpoint to include the picture URL also.  It is nice having this on the
user object to parse out in existing authentication providers such as
Google and Yahoo and having it on LinkedIn is also nice for the sake of
consistency across the spectrum of supported options.  Similar to the
Google implementation this is not promoted to a top level authenticated
context property but just hangs off of the user object graph in the
event somebody needs it to not incur the small overhead of parsing out
each time.
