### PR TITLE
GitHub: Get User's private email address

### DIFF
--- a/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
+++ b/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
@@ -90,7 +90,15 @@ namespace Owin.Security.Providers.GitHub
                 text = await userResponse.Content.ReadAsStringAsync();
                 JObject user = JObject.Parse(text);
 
-                var context = new GitHubAuthenticatedContext(Context, user, accessToken);
+                // Get the GitHub user's emails
+                HttpRequestMessage emailsRequest = new HttpRequestMessage(HttpMethod.Get, Options.Endpoints.UserEmailsEndpoint + "?access_token=" + Uri.EscapeDataString(accessToken));
+                emailsRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                HttpResponseMessage emailsResponse = await httpClient.SendAsync(emailsRequest, Request.CallCancelled);
+                emailsResponse.EnsureSuccessStatusCode();
+                text = await emailsResponse.Content.ReadAsStringAsync();
+                JArray emails = JArray.Parse(text);
+
+                var context = new GitHubAuthenticatedContext(Context, user, emails, accessToken);
                 context.Identity = new ClaimsIdentity(
                     Options.AuthenticationType,
                     ClaimsIdentity.DefaultNameClaimType,

--- a/Owin.Security.Providers/GitHub/GitHubAuthenticationOptions.cs
+++ b/Owin.Security.Providers/GitHub/GitHubAuthenticationOptions.cs
@@ -33,11 +33,20 @@ namespace Owin.Security.Providers.GitHub
             /// Defaults to https://api.github.com/user
             /// </remarks>
             public string UserInfoEndpoint { get; set; }
+
+            /// <summary>
+            /// Endpoint which is used to obtain user's emails after authentication
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://api.github.com/user/emails
+            /// </remarks>
+            public string UserEmailsEndpoint { get; set; }
         }
 
         private const string AuthorizationEndPoint = "https://github.com/login/oauth/authorize";
         private const string TokenEndpoint = "https://github.com/login/oauth/access_token";
         private const string UserInfoEndpoint = "https://api.github.com/user";
+        private const string UserEmailsEndpoint = "https://api.github.com/user/emails";
 
         /// <summary>
         ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
@@ -138,7 +147,8 @@ namespace Owin.Security.Providers.GitHub
             {
                 AuthorizationEndpoint = AuthorizationEndPoint,
                 TokenEndpoint = TokenEndpoint,
-                UserInfoEndpoint = UserInfoEndpoint
+                UserInfoEndpoint = UserInfoEndpoint,
+                UserEmailsEndpoint = UserEmailsEndpoint
             };
         }
     }


### PR DESCRIPTION
Currently if user have not set up his/her public email address ![image](https://cloud.githubusercontent.com/assets/144791/5719953/5f79184c-9b82-11e4-84ee-531e4c899980.png)

Then https://api.github.com/user will return empty string in "email" field. However user always has a private primary address which can be obtained from https://api.github.com/user/emails method
