### PR TITLE
Retrieve Salesforce Organization ID claim

### DIFF
--- a/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
@@ -134,6 +134,11 @@ namespace Owin.Security.Providers.Salesforce
                 {
                     context.Identity.AddClaim(new Claim("urn:Salesforce:name", context.DisplayName, XmlSchemaString, Options.AuthenticationType));
                 }
+
+                if (!string.IsNullOrEmpty(context.DisplayName))
+                {
+                    context.Identity.AddClaim(new Claim("urn:Salesforce:organization_id", context.OrganizationId, XmlSchemaString, Options.AuthenticationType));
+                }
                 
                 context.Properties = properties;
 

--- a/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
@@ -135,7 +135,7 @@ namespace Owin.Security.Providers.Salesforce
                     context.Identity.AddClaim(new Claim("urn:Salesforce:name", context.DisplayName, XmlSchemaString, Options.AuthenticationType));
                 }
 
-                if (!string.IsNullOrEmpty(context.DisplayName))
+                if (!string.IsNullOrEmpty(context.OrganizationId))
                 {
                     context.Identity.AddClaim(new Claim("urn:Salesforce:organization_id", context.OrganizationId, XmlSchemaString, Options.AuthenticationType));
                 }


### PR DESCRIPTION
The Salesforce Organization ID isn't currently made available. This is very useful in some scenarios including getting user information:

http://salesforce.stackexchange.com/questions/11728/salesforce-any-api-for-getting-user-information

I am also wondering if `urn:Salesforce:name` should actually be `urn:Salesforce:display_name` to be more accurate and if we should be using the "id" value returned from Salesforce instead of "userid" for `ClaimTypes.NameIdentifier`?
