### PR TITLE
fix using more than one scope for an authorization request

### DIFF
--- a/Owin.Security.Providers/Twitch/TwitchAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Twitch/TwitchAuthenticationHandler.cs
@@ -167,7 +167,7 @@ namespace Owin.Security.Providers.Twitch
                 GenerateCorrelationId(properties);
 
                 // comma separated
-                string scope = string.Join(" ", Options.Scope);
+                string scope = string.Join(" ", Options.Scope.Distinct());
 
                 string state = Options.StateDataFormat.Protect(properties);
 

--- a/Owin.Security.Providers/Twitch/TwitchAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Twitch/TwitchAuthenticationHandler.cs
@@ -167,7 +167,7 @@ namespace Owin.Security.Providers.Twitch
                 GenerateCorrelationId(properties);
 
                 // comma separated
-                string scope = string.Join(",", Options.Scope);
+                string scope = string.Join(" ", Options.Scope);
 
                 string state = Options.StateDataFormat.Protect(properties);
 


### PR DESCRIPTION
Currently, when using more than one scope, https://github.com/justintv/Twitch-API/blob/master/authentication.md#scopes, the authentication request fails because they are not concatenated correctly. They must be space-delimited, and are currently comma-delimited.
