### PR TITLE
Setup build server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build status](https://ci.appveyor.com/api/projects/status/su8q95onnarswjaq/branch/master?svg=true)](https://ci.appveyor.com/project/ByteBlast/owinoauthproviders/branch/master)
+
+
 #OWIN OAuth Providers
 
 Provides a set of extra authentication providers for OWIN ([Project Katana](http://katanaproject.codeplex.com/)).  This project includes providers for:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+version: 1.0.{build}
+before_build:
+- ps: nuget restore
+build:
+  verbosity: minimal


### PR DESCRIPTION
This should prevent dumb compiler errors from trivial changes (i.e. a small refactor) entering the code base.

OwinOAuthProviders has no tests but if we add some, the server will run those too.

In the future we can configure the build server to continuously deploy to NuGet, handling version bumping with a Powershell script.

.... And the AppVeyor badge is sexy.

AppVeyor, by the way, is free for open-source software (albeit slow).

Closes #65.
