### PR TITLE
Proposed fix for issue #57

### DIFF
--- a/Owin.Security.Providers/GooglePlus/FooExtensions.cs
+++ b/Owin.Security.Providers/GooglePlus/FooExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+
+namespace Owin.Security.Providers.GooglePlus
+{
+    /// <summary>
+    /// This was copied from Thinktecture.IdentityServer.Core.Extensions
+    /// not sure how to handle this. One option is to add a reference to the namespace above
+    /// another option is to copy that code to this project
+    /// </summary>
+    public static class FooExtensions
+    {
+        //https://github.com/IdentityServer/IdentityServer3/blob/e50124f4ca02175ea4011dab32a5cb7bea81bdab/source/Core/Extensions/OwinExtensions.cs
+        public static string GetIdentityServerBaseUrl(this IDictionary<string, object> env)
+        {
+            return env.GetIdentityServerHost() + env.GetIdentityServerBasePath();
+        }
+
+        public static string GetIdentityServerHost(this IDictionary<string, object> env)
+        {
+            return env[OwinEnvironment.IdentityServerHost] as string;
+        }
+
+        public static string GetIdentityServerBasePath(this IDictionary<string, object> env)
+        {
+            return env[OwinEnvironment.IdentityServerBasePath] as string;
+        }
+
+        // https://github.com/IdentityServer/IdentityServer3/blob/db9646650cf611f25d930c176fa2889101a0447a/source/Core/Extensions/StringsExtensions.cs
+        public static string RemoveTrailingSlash(this string url)
+        {
+            if (url != null && url.EndsWith("/"))
+            {
+                url = url.Substring(0, url.Length - 1);
+            }
+            return url;
+        }
+    }
+
+    // https://github.com/IdentityServer/IdentityServer3/blob/e50124f4ca02175ea4011dab32a5cb7bea81bdab/source/Core/Constants.cs
+    public static class OwinEnvironment
+    {
+        public const string IdentityServerBasePath = "idsrv:IdentityServerBasePath";
+        public const string IdentityServerHost = "idsrv:IdentityServerHost";
+        public const string AutofacScope = "idsrv:AutofacScope";
+        public const string RequestId = "idsrv:RequestId";
+    }
+}

--- a/Owin.Security.Providers/GooglePlus/GooglePlusAuthenticationHandler.cs
+++ b/Owin.Security.Providers/GooglePlus/GooglePlusAuthenticationHandler.cs
@@ -63,8 +63,12 @@ namespace Owin.Security.Providers.GooglePlus
                     return new AuthenticationTicket(null, properties);
                 }
 
-                string requestPrefix = Request.Scheme + "://" + Request.Host;
-                string redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
+                string baseUri = Context.Environment
+                                        .GetIdentityServerBaseUrl()
+                                        .RemoveTrailingSlash();
+
+                string redirectUri = baseUri +
+                                     Options.CallbackPath;
 
                 // Build up the body for the token request
                 var body = new List<KeyValuePair<string, string>>();
@@ -151,20 +155,17 @@ namespace Owin.Security.Providers.GooglePlus
 
             if (challenge != null)
             {
-                string baseUri =
-                    Request.Scheme +
-                    Uri.SchemeDelimiter +
-                    Request.Host +
-                    Request.PathBase;
+                string baseUri = Context.Environment
+                                        .GetIdentityServerBaseUrl()
+                                        .RemoveTrailingSlash();
 
                 string currentUri =
                     baseUri +
                     Request.Path +
                     Request.QueryString;
 
-                string redirectUri =
-                    baseUri +
-                    Options.CallbackPath;
+                string redirectUri = baseUri +
+                                     Options.CallbackPath;
 
                 AuthenticationProperties properties = challenge.Properties;
                 if (string.IsNullOrEmpty(properties.RedirectUri))

--- a/Owin.Security.Providers/Owin.Security.Providers.csproj
+++ b/Owin.Security.Providers/Owin.Security.Providers.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Foursquare\Provider\FoursquareReturnEndpointContext.cs" />
     <Compile Include="Foursquare\Provider\IFoursquareAuthenticationProvider.cs" />
     <Compile Include="GitHub\Constants.cs" />
+    <Compile Include="GooglePlus\FooExtensions.cs" />
     <Compile Include="HealthGraph\Constants.cs" />
     <Compile Include="GitHub\GitHubAuthenticationExtensions.cs" />
     <Compile Include="GitHub\GitHubAuthenticationHandler.cs" />


### PR DESCRIPTION
This is an initial draft of fix for issue #57 

It covers only the GooglePlus provider but the problem also exists in other providers that use Request.Host to calculate URIs

Also, the fix uses some code from IdentityServer Extensions, not sure if that reference can be added or better to have some internal code that does the same thing. See FooExtensions.cs in the changed files.
