### PR TITLE
Simplify Steam auth options overrides

### DIFF
--- a/Owin.Security.Providers/Steam/SteamAuthenticationExtensions.cs
+++ b/Owin.Security.Providers/Steam/SteamAuthenticationExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Owin;
-using System;
+﻿using System;
 
 namespace Owin.Security.Providers.Steam
 {
@@ -25,8 +24,7 @@ namespace Owin.Security.Providers.Steam
                 throw new ArgumentNullException("options");
             }
 
-            app.Use(typeof(SteamAuthenticationMiddleware), app, options);
-            return app;
+            return app.Use(typeof(SteamAuthenticationMiddleware), app, options);
         }
 
         /// <summary>
@@ -39,10 +37,6 @@ namespace Owin.Security.Providers.Steam
         {
             return UseSteamAuthentication(app, new SteamAuthenticationOptions
             {
-                ProviderDiscoveryUri = "http://steamcommunity.com/openid/",
-                Caption = "Steam",
-                AuthenticationType = "Steam",
-                CallbackPath = new PathString("/signin-openidsteam"),
                 ApplicationKey = applicationKey
             });
         }

--- a/Owin.Security.Providers/Steam/SteamAuthenticationOptions.cs
+++ b/Owin.Security.Providers/Steam/SteamAuthenticationOptions.cs
@@ -1,9 +1,18 @@
-﻿using Owin.Security.Providers.OpenID;
+﻿using Microsoft.Owin;
+using Owin.Security.Providers.OpenID;
 
 namespace Owin.Security.Providers.Steam
 {
     public sealed class SteamAuthenticationOptions : OpenIDAuthenticationOptions
     {
         public string ApplicationKey { get; set; }
+
+        public SteamAuthenticationOptions()
+        {
+            ProviderDiscoveryUri = "http://steamcommunity.com/openid/";
+            Caption = "Steam";
+            AuthenticationType = "Steam";
+            CallbackPath = new PathString("/signin-openidsteam");
+        }
     }
 }


### PR DESCRIPTION
Simplify the Steam authentication options overrides.
The user doesn't need to specify each time the uri, name or callback path anymore.

Cleaner history and modifications than the #77.
