### PR TITLE
Reddit Scope property change

### DIFF
--- a/Owin.Security.Providers/Reddit/RedditAuthenticationOptions.cs
+++ b/Owin.Security.Providers/Reddit/RedditAuthenticationOptions.cs
@@ -71,7 +71,7 @@ namespace Owin.Security.Providers.Reddit
         /// <summary>
         /// A list of permissions to request.
         /// </summary>
-        public IList<string> Scope { get; private set; }
+        public IList<string> Scope { get; set; }
 
         /// <summary>
         ///     Gets or sets the name of another authentication middleware which will be responsible for actually issuing a user


### PR DESCRIPTION
Changed private setter on Scope option to allow setting of property to only the level of access you actually need. No need to only allow a specific amount of access or require users to give up access to private messages to use Reddit auth.
