### PR TITLE
BugFix.

### DIFF
--- a/Owin.Security.Providers/Backlog/BacklogAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Backlog/BacklogAuthenticationHandler.cs
@@ -72,6 +72,7 @@ namespace Owin.Security.Providers.Backlog
                 body.Add(new KeyValuePair<string, string>("client_secret", Options.ClientSecret));
 
                 // Get token
+                httpClient.DefaultRequestHeaders.Authorization = null;
                 HttpResponseMessage tokenResponse =
                     await httpClient.PostAsync(Options.TokenEndpoint, new FormUrlEncodedContent(body));
                 tokenResponse.EnsureSuccessStatusCode();


### PR DESCRIPTION
Clear authorization header before request access token.
Backlog OAuth Provider check the old token in authorization header and return 400 error.
