### PR TITLE
Add Salesforce timezone as claim.

### DIFF
--- a/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
@@ -135,7 +135,12 @@ namespace Owin.Security.Providers.Salesforce
                 {
                     context.Identity.AddClaim(new Claim("urn:Salesforce:organization_id", context.OrganizationId, XmlSchemaString, Options.AuthenticationType));
                 }
-                
+
+                if (!string.IsNullOrEmpty(context.TimeZone))
+                {
+                    context.Identity.AddClaim(new Claim("urn:Salesforce:timezone", context.TimeZone, XmlSchemaString, Options.AuthenticationType));
+                }
+
                 context.Properties = properties;
 
                 await Options.Provider.Authenticated(context);


### PR DESCRIPTION
We've read the timezone from the Salesforce return data but we're not adding it as a claim, making it inaccessible. Providing the user's timezone can be useful.
