### PR TITLE
Added Shopify Domain Property to fetch after authorization

### DIFF
--- a/Owin.Security.Providers/Shopify/Provider/ShopifyAuthenticatedContext.cs
+++ b/Owin.Security.Providers/Shopify/Provider/ShopifyAuthenticatedContext.cs
@@ -25,6 +25,7 @@
             UserName = string.IsNullOrWhiteSpace(fullShopifyDomainName) ? null : fullShopifyDomainName.Replace(".myshopify.com", "");
             Email = TryGetValue(shop, "email");
             ShopName = TryGetValue(shop, "name");
+            ShopifyDomain = fullShopifyDomainName;
         }
 
         /// <summary>
@@ -58,6 +59,11 @@
         /// Gets the Shopify shop name.
         /// </summary>
         public string ShopName { get; private set; }
+
+        /// <summary>
+        /// Gets the Shopify domain name.
+        /// </summary>
+        public string ShopifyDomain { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ClaimsIdentity"/> representing the Shopify shop.

--- a/Owin.Security.Providers/Shopify/ShopifyAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Shopify/ShopifyAuthenticationHandler.cs
@@ -118,7 +118,7 @@
 
                 if (!string.IsNullOrEmpty(context.ShopName))
                 {
-                    context.Identity.AddClaim(new Claim("urn:shopify:shopname", context.ShopName, XmlSchemaString, Options.AuthenticationType));
+                    context.Identity.AddClaim(new Claim("urn:shopify:shopdomain", context.ShopifyDomain, XmlSchemaString, Options.AuthenticationType));
                 }
 
                 context.Properties = properties;


### PR DESCRIPTION
Shopify Shop Name is something which can be changed as per shop owner's choice from Shop Admin's setting page.

This is a label / string that can have space and can be way different then the Shop Name (the one seen in URL).

Two important and primary info application developer would need after authorization would be the **URL / Shopify domain name** (to make the API calls after authorization) and **Access Token** (to make the API calls obviously :laughing: )

I am still keeping the `ShopName` property for devs. to access but introduced new property called `ShopifyDomain` that contains the URL or domain name - e.g. `jsinh.myshopify.com` or `rockstarslabs.myshopify.com`.

Claims updated accordingly to have `urn:shopify:shopdomain` instead of name which IMO should not be saved as it can be updated.

**Side note:** Shopify Domain Name always remains same until the shop is destroyed or closed.

Thanks in advance for accepting the PR :+1: 
