### PR TITLE
Added Bitbucket provider

### DIFF
--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationExtensions.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationExtensions.cs
@@ -4,7 +4,7 @@ namespace Owin.Security.Providers.Bitbucket
 {
     public static class BitbucketAuthenticationExtensions
     {
-        public static IAppBuilder UseGitHubAuthentication(this IAppBuilder app,
+        public static IAppBuilder UseBitbucketAuthentication(this IAppBuilder app,
             BitbucketAuthenticationOptions options)
         {
             if (app == null)
@@ -17,9 +17,9 @@ namespace Owin.Security.Providers.Bitbucket
             return app;
         }
 
-        public static IAppBuilder UseGitHubAuthentication(this IAppBuilder app, string clientId, string clientSecret)
+        public static IAppBuilder UseBitbucketAuthentication(this IAppBuilder app, string clientId, string clientSecret)
         {
-            return app.UseGitHubAuthentication(new BitbucketAuthenticationOptions
+            return app.UseBitbucketAuthentication(new BitbucketAuthenticationOptions
             {
                 ClientId = clientId,
                 ClientSecret = clientSecret

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationExtensions.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    public static class BitbucketAuthenticationExtensions
+    {
+        public static IAppBuilder UseGitHubAuthentication(this IAppBuilder app,
+            BitbucketAuthenticationOptions options)
+        {
+            if (app == null)
+                throw new ArgumentNullException("app");
+            if (options == null)
+                throw new ArgumentNullException("options");
+
+            app.Use(typeof(BitbucketAuthenticationMiddleware), app, options);
+
+            return app;
+        }
+
+        public static IAppBuilder UseGitHubAuthentication(this IAppBuilder app, string clientId, string clientSecret)
+        {
+            return app.UseGitHubAuthentication(new BitbucketAuthenticationOptions
+            {
+                ClientId = clientId,
+                ClientSecret = clientSecret
+            });
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationHandler.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    public class BitbucketAuthenticationHandler : AuthenticationHandler<BitbucketAuthenticationOptions>
+    {
+        private const string XmlSchemaString = "http://www.w3.org/2001/XMLSchema#string";
+
+        private readonly ILogger logger;
+        private readonly HttpClient httpClient;
+
+        public BitbucketAuthenticationHandler(HttpClient httpClient, ILogger logger)
+        {
+            this.httpClient = httpClient;
+            this.logger = logger;
+        }
+
+        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        {
+            AuthenticationProperties properties = null;
+
+            try
+            {
+                string code = null;
+                string state = null;
+
+                IReadableStringCollection query = Request.Query;
+                IList<string> values = query.GetValues("code");
+                if (values != null && values.Count == 1)
+                {
+                    code = values[0];
+                }
+                values = query.GetValues("state");
+                if (values != null && values.Count == 1)
+                {
+                    state = values[0];
+                }
+
+                properties = Options.StateDataFormat.Unprotect(state);
+                if (properties == null)
+                {
+                    return null;
+                }
+
+                // OAuth2 10.12 CSRF
+                if (!ValidateCorrelationId(properties, logger))
+                {
+                    return new AuthenticationTicket(null, properties);
+                }
+
+                string requestPrefix = Request.Scheme + "://" + Request.Host;
+                string redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
+
+                // Build up the body for the token request
+                var body = new List<KeyValuePair<string, string>>();
+                body.Add(new KeyValuePair<string, string>("code", code));
+                body.Add(new KeyValuePair<string, string>("redirect_uri", redirectUri));
+                body.Add(new KeyValuePair<string, string>("client_id", Options.ClientId));
+                body.Add(new KeyValuePair<string, string>("client_secret", Options.ClientSecret));
+
+                // Request the token
+                var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.Endpoints.TokenEndpoint);
+                requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                requestMessage.Content = new FormUrlEncodedContent(body);
+                HttpResponseMessage tokenResponse = await httpClient.SendAsync(requestMessage);
+                tokenResponse.EnsureSuccessStatusCode();
+                string text = await tokenResponse.Content.ReadAsStringAsync();
+
+                // Deserializes the token response
+                dynamic response = JsonConvert.DeserializeObject<dynamic>(text);
+                string accessToken = (string)response.access_token;
+
+                // Get the GitHub user
+                HttpRequestMessage userRequest = new HttpRequestMessage(HttpMethod.Get, Options.Endpoints.UserInfoEndpoint + "?access_token=" + Uri.EscapeDataString(accessToken));
+                userRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                HttpResponseMessage userResponse = await httpClient.SendAsync(userRequest, Request.CallCancelled);
+                userResponse.EnsureSuccessStatusCode();
+                text = await userResponse.Content.ReadAsStringAsync();
+                JObject user = JObject.Parse(text);
+
+                var context = new BitbucketAuthenticatedContext(Context, user, accessToken);
+                context.Identity = new ClaimsIdentity(
+                    Options.AuthenticationType,
+                    ClaimsIdentity.DefaultNameClaimType,
+                    ClaimsIdentity.DefaultRoleClaimType);
+                if (!string.IsNullOrEmpty(context.Id))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, context.Id, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.UserName))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.UserName, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.Email))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.Name))
+                {
+                    context.Identity.AddClaim(new Claim("urn:github:name", context.Name, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.Link))
+                {
+                    context.Identity.AddClaim(new Claim("urn:github:url", context.Link, XmlSchemaString, Options.AuthenticationType));
+                }
+                context.Properties = properties;
+
+                await Options.Provider.Authenticated(context);
+
+                return new AuthenticationTicket(context.Identity, context.Properties);
+            }
+            catch (Exception ex)
+            {
+                logger.WriteError(ex.Message);
+            }
+            return new AuthenticationTicket(null, properties);
+        }
+
+        protected override Task ApplyResponseChallengeAsync()
+        {
+            if (Response.StatusCode != 401)
+            {
+                return Task.FromResult<object>(null);
+            }
+
+            AuthenticationResponseChallenge challenge = Helper.LookupChallenge(Options.AuthenticationType, Options.AuthenticationMode);
+
+            if (challenge != null)
+            {
+                string baseUri =
+                    Request.Scheme +
+                    Uri.SchemeDelimiter +
+                    Request.Host +
+                    Request.PathBase;
+
+                string currentUri =
+                    baseUri +
+                    Request.Path +
+                    Request.QueryString;
+
+                string redirectUri =
+                    baseUri +
+                    Options.CallbackPath;
+
+                AuthenticationProperties properties = challenge.Properties;
+                if (string.IsNullOrEmpty(properties.RedirectUri))
+                {
+                    properties.RedirectUri = currentUri;
+                }
+
+                // OAuth2 10.12 CSRF
+                GenerateCorrelationId(properties);
+
+                // comma separated
+                string scope = string.Join(",", Options.Scope);
+
+                string state = Options.StateDataFormat.Protect(properties);
+
+                string authorizationEndpoint =
+                    Options.Endpoints.AuthorizationEndpoint +
+                        "?client_id=" + Uri.EscapeDataString(Options.ClientId) +
+                        "&redirect_uri=" + Uri.EscapeDataString(redirectUri) +
+                        "&scope=" + Uri.EscapeDataString(scope) +
+                        "&state=" + Uri.EscapeDataString(state);
+
+                Response.Redirect(authorizationEndpoint);
+            }
+
+            return Task.FromResult<object>(null);
+        }
+
+        public override async Task<bool> InvokeAsync()
+        {
+            return await InvokeReplyPathAsync();
+        }
+
+        private async Task<bool> InvokeReplyPathAsync()
+        {
+            if (Options.CallbackPath.HasValue && Options.CallbackPath == Request.Path)
+            {
+                // TODO: error responses
+
+                AuthenticationTicket ticket = await AuthenticateAsync();
+                if (ticket == null)
+                {
+                    logger.WriteWarning("Invalid return state, unable to redirect.");
+                    Response.StatusCode = 500;
+                    return true;
+                }
+
+                var context = new BitbucketReturnEndpointContext(Context, ticket);
+                context.SignInAsAuthenticationType = Options.SignInAsAuthenticationType;
+                context.RedirectUri = ticket.Properties.RedirectUri;
+
+                await Options.Provider.ReturnEndpoint(context);
+
+                if (context.SignInAsAuthenticationType != null &&
+                    context.Identity != null)
+                {
+                    ClaimsIdentity grantIdentity = context.Identity;
+                    if (!string.Equals(grantIdentity.AuthenticationType, context.SignInAsAuthenticationType, StringComparison.Ordinal))
+                    {
+                        grantIdentity = new ClaimsIdentity(grantIdentity.Claims, context.SignInAsAuthenticationType, grantIdentity.NameClaimType, grantIdentity.RoleClaimType);
+                    }
+                    Context.Authentication.SignIn(context.Properties, grantIdentity);
+                }
+
+                if (!context.IsRequestCompleted && context.RedirectUri != null)
+                {
+                    string redirectUri = context.RedirectUri;
+                    if (context.Identity == null)
+                    {
+                        // add a redirect hint that sign-in failed in some way
+                        redirectUri = WebUtilities.AddQueryString(redirectUri, "error", "access_denied");
+                    }
+                    Response.Redirect(redirectUri);
+                    context.RequestCompleted();
+                }
+
+                return context.IsRequestCompleted;
+            }
+            return false;
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationHandler.cs
@@ -82,7 +82,7 @@ namespace Owin.Security.Providers.Bitbucket
                 dynamic response = JsonConvert.DeserializeObject<dynamic>(text);
                 string accessToken = (string)response.access_token;
 
-                // Get the GitHub user
+                // Get the Bitbucket user
                 HttpRequestMessage userRequest = new HttpRequestMessage(HttpMethod.Get, Options.Endpoints.UserInfoEndpoint + "?access_token=" + Uri.EscapeDataString(accessToken));
                 userRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 HttpResponseMessage userResponse = await httpClient.SendAsync(userRequest, Request.CallCancelled);
@@ -109,11 +109,11 @@ namespace Owin.Security.Providers.Bitbucket
                 }
                 if (!string.IsNullOrEmpty(context.Name))
                 {
-                    context.Identity.AddClaim(new Claim("urn:github:name", context.Name, XmlSchemaString, Options.AuthenticationType));
+                    context.Identity.AddClaim(new Claim("urn:bitbucket:name", context.Name, XmlSchemaString, Options.AuthenticationType));
                 }
                 if (!string.IsNullOrEmpty(context.Link))
                 {
-                    context.Identity.AddClaim(new Claim("urn:github:url", context.Link, XmlSchemaString, Options.AuthenticationType));
+                    context.Identity.AddClaim(new Claim("urn:bitbucket:url", context.Link, XmlSchemaString, Options.AuthenticationType));
                 }
                 context.Properties = properties;
 

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationMiddleware.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationMiddleware.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Globalization;
+using System.Net.Http;
+using Microsoft.Owin;
+using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.DataHandler;
+using Microsoft.Owin.Security.DataProtection;
+using Microsoft.Owin.Security.Infrastructure;
+using Owin.Security.Providers.Properties;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    public class BitbucketAuthenticationMiddleware : AuthenticationMiddleware<BitbucketAuthenticationOptions>
+    {
+        private readonly HttpClient httpClient;
+        private readonly ILogger logger;
+
+        public BitbucketAuthenticationMiddleware(OwinMiddleware next, IAppBuilder app,
+            BitbucketAuthenticationOptions options)
+            : base(next, options)
+        {
+            if (String.IsNullOrWhiteSpace(Options.ClientId))
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture,
+                    Resources.Exception_OptionMustBeProvided, "ClientId"));
+            if (String.IsNullOrWhiteSpace(Options.ClientSecret))
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture,
+                    Resources.Exception_OptionMustBeProvided, "ClientSecret"));
+
+            logger = app.CreateLogger<BitbucketAuthenticationMiddleware>();
+
+            if (Options.Provider == null)
+                Options.Provider = new BitbucketAuthenticationProvider();
+
+            if (Options.StateDataFormat == null)
+            {
+                IDataProtector dataProtector = app.CreateDataProtector(
+                    typeof (BitbucketAuthenticationMiddleware).FullName,
+                    Options.AuthenticationType, "v1");
+                Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+            }
+
+            if (String.IsNullOrEmpty(Options.SignInAsAuthenticationType))
+                Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
+
+            httpClient = new HttpClient(ResolveHttpMessageHandler(Options))
+            {
+                Timeout = Options.BackchannelTimeout,
+                MaxResponseContentBufferSize = 1024*1024*10,
+            };
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft Owin GitHub middleware");
+            httpClient.DefaultRequestHeaders.ExpectContinue = false;
+        }
+
+        /// <summary>
+        ///     Provides the <see cref="T:Microsoft.Owin.Security.Infrastructure.AuthenticationHandler" /> object for processing
+        ///     authentication-related requests.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="T:Microsoft.Owin.Security.Infrastructure.AuthenticationHandler" /> configured with the
+        ///     <see cref="T:Owin.Security.Providers.GitHub.GitHubAuthenticationOptions" /> supplied to the constructor.
+        /// </returns>
+        protected override AuthenticationHandler<BitbucketAuthenticationOptions> CreateHandler()
+        {
+            return new BitbucketAuthenticationHandler(httpClient, logger);
+        }
+
+        private HttpMessageHandler ResolveHttpMessageHandler(BitbucketAuthenticationOptions options)
+        {
+            HttpMessageHandler handler = options.BackchannelHttpHandler ?? new WebRequestHandler();
+
+            // If they provided a validator, apply it or fail.
+            if (options.BackchannelCertificateValidator != null)
+            {
+                // Set the cert validate callback
+                var webRequestHandler = handler as WebRequestHandler;
+                if (webRequestHandler == null)
+                {
+                    throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
+                }
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+            }
+
+            return handler;
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationMiddleware.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationMiddleware.cs
@@ -48,7 +48,7 @@ namespace Owin.Security.Providers.Bitbucket
                 Timeout = Options.BackchannelTimeout,
                 MaxResponseContentBufferSize = 1024*1024*10,
             };
-            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft Owin GitHub middleware");
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft Owin Bitbucket middleware");
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
         }
 

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationOptions.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationOptions.cs
@@ -11,10 +11,10 @@ namespace Owin.Security.Providers.Bitbucket
         public class BitbucketAuthenticationEndpoints
         {
             /// <summary>
-            /// Endpoint which is used to redirect users to request GitHub access
+            /// Endpoint which is used to redirect users to request Bitbucket access
             /// </summary>
             /// <remarks>
-            /// Defaults to https://github.com/login/oauth/authorize
+            /// Defaults to https://bitbucket.org/site/oauth2/authorize
             /// </remarks>
             public string AuthorizationEndpoint { get; set; }
 
@@ -22,7 +22,7 @@ namespace Owin.Security.Providers.Bitbucket
             /// Endpoint which is used to exchange code for access token
             /// </summary>
             /// <remarks>
-            /// Defaults to https://github.com/login/oauth/access_token
+            /// Defaults to https://bitbucket.org/site/oauth2/access_token
             /// </remarks>
             public string TokenEndpoint { get; set; }
 
@@ -30,18 +30,18 @@ namespace Owin.Security.Providers.Bitbucket
             /// Endpoint which is used to obtain user information after authentication
             /// </summary>
             /// <remarks>
-            /// Defaults to https://api.github.com/user
+            /// Defaults to https://api.bitbucket.org/2.0/user
             /// </remarks>
             public string UserInfoEndpoint { get; set; }
         }
 
-        private const string AuthorizationEndPoint = "https://github.com/login/oauth/authorize";
-        private const string TokenEndpoint = "https://github.com/login/oauth/access_token";
-        private const string UserInfoEndpoint = "https://api.github.com/user";
+        private const string AuthorizationEndPoint = "https://bitbucket.org/site/oauth2/authorize";
+        private const string TokenEndpoint = "https://bitbucket.org/site/oauth2/access_token";
+        private const string UserInfoEndpoint = "https://bitbucket.org/api/2.0/users/{0}";
 
         /// <summary>
         ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
-        ///     in back channel communications belong to GitHub.
+        ///     in back channel communications belong to Bitbucket.
         /// </summary>
         /// <value>
         ///     The pinned certificate validator.
@@ -53,14 +53,14 @@ namespace Owin.Security.Providers.Bitbucket
         public ICertificateValidator BackchannelCertificateValidator { get; set; }
 
         /// <summary>
-        ///     The HttpMessageHandler used to communicate with GitHub.
+        ///     The HttpMessageHandler used to communicate with Bitbucket.
         ///     This cannot be set at the same time as BackchannelCertificateValidator unless the value
         ///     can be downcast to a WebRequestHandler.
         /// </summary>
         public HttpMessageHandler BackchannelHttpHandler { get; set; }
 
         /// <summary>
-        ///     Gets or sets timeout value in milliseconds for back channel communications with GitHub.
+        ///     Gets or sets timeout value in milliseconds for back channel communications with Bitbucket.
         /// </summary>
         /// <value>
         ///     The back channel timeout in milliseconds.
@@ -70,7 +70,7 @@ namespace Owin.Security.Providers.Bitbucket
         /// <summary>
         ///     The request path within the application's base path where the user-agent will be returned.
         ///     The middleware will process this request when it arrives.
-        ///     Default value is "/signin-github".
+        ///     Default value is "/signin-bitbucket".
         /// </summary>
         public PathString CallbackPath { get; set; }
 
@@ -84,17 +84,17 @@ namespace Owin.Security.Providers.Bitbucket
         }
 
         /// <summary>
-        ///     Gets or sets the GitHub supplied Client ID
+        ///     Gets or sets the Bitbucket supplied Client ID
         /// </summary>
         public string ClientId { get; set; }
 
         /// <summary>
-        ///     Gets or sets the GitHub supplied Client Secret
+        ///     Gets or sets the Bitbucket supplied Client Secret
         /// </summary>
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// Gets the sets of OAuth endpoints used to authenticate against GitHub.  Overriding these endpoints allows you to use GitHub Enterprise for
+        /// Gets the sets of OAuth endpoints used to authenticate against Bitbucket.  Overriding these endpoints allows you to use Bitbucket Enterprise for
         /// authentication.
         /// </summary>
         public BitbucketAuthenticationEndpoints Endpoints { get; set; }
@@ -124,10 +124,10 @@ namespace Owin.Security.Providers.Bitbucket
         ///     Initializes a new <see cref="BitbucketAuthenticationOptions" />
         /// </summary>
         public BitbucketAuthenticationOptions()
-            : base("GitHub")
+            : base("Bitbucket")
         {
             Caption = Constants.DefaultAuthenticationType;
-            CallbackPath = new PathString("/signin-github");
+            CallbackPath = new PathString("/signin-bitbucket");
             AuthenticationMode = AuthenticationMode.Passive;
             Scope = new List<string>
             {

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationOptions.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationOptions.cs
@@ -37,7 +37,7 @@ namespace Owin.Security.Providers.Bitbucket
 
         private const string AuthorizationEndPoint = "https://bitbucket.org/site/oauth2/authorize";
         private const string TokenEndpoint = "https://bitbucket.org/site/oauth2/access_token";
-        private const string UserInfoEndpoint = "https://bitbucket.org/api/2.0/users/{0}";
+        private const string UserInfoEndpoint = "https://api.bitbucket.org/2.0/user";
 
         /// <summary>
         ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
@@ -129,10 +129,13 @@ namespace Owin.Security.Providers.Bitbucket
             Caption = Constants.DefaultAuthenticationType;
             CallbackPath = new PathString("/signin-bitbucket");
             AuthenticationMode = AuthenticationMode.Passive;
-            Scope = new List<string>
-            {
-                "user"
-            };
+
+            // Bitbucket does not support the scope parameter
+            // https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes
+            //Scope = new List<string>
+            //{
+            //    "user"
+            //};
             BackchannelTimeout = TimeSpan.FromSeconds(60);
             Endpoints = new BitbucketAuthenticationEndpoints
             {

--- a/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationOptions.cs
+++ b/Owin.Security.Providers/Bitbucket/BitbucketAuthenticationOptions.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    public class BitbucketAuthenticationOptions : AuthenticationOptions
+    {
+        public class BitbucketAuthenticationEndpoints
+        {
+            /// <summary>
+            /// Endpoint which is used to redirect users to request GitHub access
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://github.com/login/oauth/authorize
+            /// </remarks>
+            public string AuthorizationEndpoint { get; set; }
+
+            /// <summary>
+            /// Endpoint which is used to exchange code for access token
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://github.com/login/oauth/access_token
+            /// </remarks>
+            public string TokenEndpoint { get; set; }
+
+            /// <summary>
+            /// Endpoint which is used to obtain user information after authentication
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://api.github.com/user
+            /// </remarks>
+            public string UserInfoEndpoint { get; set; }
+        }
+
+        private const string AuthorizationEndPoint = "https://github.com/login/oauth/authorize";
+        private const string TokenEndpoint = "https://github.com/login/oauth/access_token";
+        private const string UserInfoEndpoint = "https://api.github.com/user";
+
+        /// <summary>
+        ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
+        ///     in back channel communications belong to GitHub.
+        /// </summary>
+        /// <value>
+        ///     The pinned certificate validator.
+        /// </value>
+        /// <remarks>
+        ///     If this property is null then the default certificate checks are performed,
+        ///     validating the subject name and if the signing chain is a trusted party.
+        /// </remarks>
+        public ICertificateValidator BackchannelCertificateValidator { get; set; }
+
+        /// <summary>
+        ///     The HttpMessageHandler used to communicate with GitHub.
+        ///     This cannot be set at the same time as BackchannelCertificateValidator unless the value
+        ///     can be downcast to a WebRequestHandler.
+        /// </summary>
+        public HttpMessageHandler BackchannelHttpHandler { get; set; }
+
+        /// <summary>
+        ///     Gets or sets timeout value in milliseconds for back channel communications with GitHub.
+        /// </summary>
+        /// <value>
+        ///     The back channel timeout in milliseconds.
+        /// </value>
+        public TimeSpan BackchannelTimeout { get; set; }
+
+        /// <summary>
+        ///     The request path within the application's base path where the user-agent will be returned.
+        ///     The middleware will process this request when it arrives.
+        ///     Default value is "/signin-github".
+        /// </summary>
+        public PathString CallbackPath { get; set; }
+
+        /// <summary>
+        ///     Get or sets the text that the user can display on a sign in user interface.
+        /// </summary>
+        public string Caption
+        {
+            get { return Description.Caption; }
+            set { Description.Caption = value; }
+        }
+
+        /// <summary>
+        ///     Gets or sets the GitHub supplied Client ID
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the GitHub supplied Client Secret
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Gets the sets of OAuth endpoints used to authenticate against GitHub.  Overriding these endpoints allows you to use GitHub Enterprise for
+        /// authentication.
+        /// </summary>
+        public BitbucketAuthenticationEndpoints Endpoints { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the <see cref="IBitbucketAuthenticationProvider" /> used in the authentication events
+        /// </summary>
+        public IBitbucketAuthenticationProvider Provider { get; set; }
+
+        /// <summary>
+        /// A list of permissions to request.
+        /// </summary>
+        public IList<string> Scope { get; private set; }
+
+        /// <summary>
+        ///     Gets or sets the name of another authentication middleware which will be responsible for actually issuing a user
+        ///     <see cref="System.Security.Claims.ClaimsIdentity" />.
+        /// </summary>
+        public string SignInAsAuthenticationType { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the type used to secure data handled by the middleware.
+        /// </summary>
+        public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
+
+        /// <summary>
+        ///     Initializes a new <see cref="BitbucketAuthenticationOptions" />
+        /// </summary>
+        public BitbucketAuthenticationOptions()
+            : base("GitHub")
+        {
+            Caption = Constants.DefaultAuthenticationType;
+            CallbackPath = new PathString("/signin-github");
+            AuthenticationMode = AuthenticationMode.Passive;
+            Scope = new List<string>
+            {
+                "user"
+            };
+            BackchannelTimeout = TimeSpan.FromSeconds(60);
+            Endpoints = new BitbucketAuthenticationEndpoints
+            {
+                AuthorizationEndpoint = AuthorizationEndPoint,
+                TokenEndpoint = TokenEndpoint,
+                UserInfoEndpoint = UserInfoEndpoint
+            };
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/Constants.cs
+++ b/Owin.Security.Providers/Bitbucket/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Owin.Security.Providers.Bitbucket
+{
+    internal static class Constants
+    {
+        public const string DefaultAuthenticationType = "Bitbucket";
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticatedContext.cs
+++ b/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticatedContext.cs
@@ -20,7 +20,7 @@ namespace Owin.Security.Providers.Bitbucket
         /// </summary>
         /// <param name="context">The OWIN environment</param>
         /// <param name="user">The JSON-serialized user</param>
-        /// <param name="accessToken">GitHub Access token</param>
+        /// <param name="accessToken">Bitbucket Access token</param>
         public BitbucketAuthenticatedContext(IOwinContext context, JObject user, string accessToken)
             : base(context)
         {
@@ -38,18 +38,18 @@ namespace Owin.Security.Providers.Bitbucket
         /// Gets the JSON-serialized user
         /// </summary>
         /// <remarks>
-        /// Contains the GitHub user obtained from the User Info endpoint. By default this is https://api.github.com/user but it can be
+        /// Contains the Bitbucket user obtained from the User Info endpoint. By default this is https://api.bitbucket.org/2.0/user but it can be
         /// overridden in the options
         /// </remarks>
         public JObject User { get; private set; }
 
         /// <summary>
-        /// Gets the GitHub access token
+        /// Gets the Bitbucket access token
         /// </summary>
         public string AccessToken { get; private set; }
 
         /// <summary>
-        /// Gets the GitHub user ID
+        /// Gets the Bitbucket user ID
         /// </summary>
         public string Id { get; private set; }
 
@@ -61,12 +61,12 @@ namespace Owin.Security.Providers.Bitbucket
         public string Link { get; private set; }
 
         /// <summary>
-        /// Gets the GitHub username
+        /// Gets the Bitbucket username
         /// </summary>
         public string UserName { get; private set; }
 
         /// <summary>
-        /// Gets the GitHub email
+        /// Gets the Bitbucket email
         /// </summary>
         public string Email { get; private set; }
 

--- a/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticatedContext.cs
+++ b/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticatedContext.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Security.Claims;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Provider;
+using Newtonsoft.Json.Linq;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    /// <summary>
+    /// Contains information about the login session as well as the user <see cref="System.Security.Claims.ClaimsIdentity"/>.
+    /// </summary>
+    public class BitbucketAuthenticatedContext : BaseContext
+    {
+        /// <summary>
+        /// Initializes a <see cref="BitbucketAuthenticatedContext"/>
+        /// </summary>
+        /// <param name="context">The OWIN environment</param>
+        /// <param name="user">The JSON-serialized user</param>
+        /// <param name="accessToken">GitHub Access token</param>
+        public BitbucketAuthenticatedContext(IOwinContext context, JObject user, string accessToken)
+            : base(context)
+        {
+            User = user;
+            AccessToken = accessToken;
+
+            Id = TryGetValue(user, "id");
+            Name = TryGetValue(user, "name");
+            Link = TryGetValue(user, "url");
+            UserName = TryGetValue(user, "login");
+            Email = TryGetValue(user, "email");
+        }
+
+        /// <summary>
+        /// Gets the JSON-serialized user
+        /// </summary>
+        /// <remarks>
+        /// Contains the GitHub user obtained from the User Info endpoint. By default this is https://api.github.com/user but it can be
+        /// overridden in the options
+        /// </remarks>
+        public JObject User { get; private set; }
+
+        /// <summary>
+        /// Gets the GitHub access token
+        /// </summary>
+        public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// Gets the GitHub user ID
+        /// </summary>
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// Gets the user's name
+        /// </summary>
+        public string Name { get; private set; }
+
+        public string Link { get; private set; }
+
+        /// <summary>
+        /// Gets the GitHub username
+        /// </summary>
+        public string UserName { get; private set; }
+
+        /// <summary>
+        /// Gets the GitHub email
+        /// </summary>
+        public string Email { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ClaimsIdentity"/> representing the user
+        /// </summary>
+        public ClaimsIdentity Identity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a property bag for common authentication properties
+        /// </summary>
+        public AuthenticationProperties Properties { get; set; }
+
+        private static string TryGetValue(JObject user, string propertyName)
+        {
+            JToken value;
+            return user.TryGetValue(propertyName, out value) ? value.ToString() : null;
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticatedContext.cs
+++ b/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticatedContext.cs
@@ -27,10 +27,10 @@ namespace Owin.Security.Providers.Bitbucket
             User = user;
             AccessToken = accessToken;
 
-            Id = TryGetValue(user, "id");
-            Name = TryGetValue(user, "name");
-            Link = TryGetValue(user, "url");
-            UserName = TryGetValue(user, "login");
+            Id = TryGetValue(user, "uuid");
+            Name = TryGetValue(user, "display_name");
+            Link = TryGetValue(user, "website");
+            UserName = TryGetValue(user, "username");
             Email = TryGetValue(user, "email");
         }
 

--- a/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticationProvider.cs
+++ b/Owin.Security.Providers/Bitbucket/Provider/BitbucketAuthenticationProvider.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    /// <summary>
+    /// Default <see cref="IBitbucketAuthenticationProvider"/> implementation.
+    /// </summary>
+    public class BitbucketAuthenticationProvider : IBitbucketAuthenticationProvider
+    {
+        /// <summary>
+        /// Initializes a <see cref="BitbucketAuthenticationProvider"/>
+        /// </summary>
+        public BitbucketAuthenticationProvider()
+        {
+            OnAuthenticated = context => Task.FromResult<object>(null);
+            OnReturnEndpoint = context => Task.FromResult<object>(null);
+        }
+
+        /// <summary>
+        /// Gets or sets the function that is invoked when the Authenticated method is invoked.
+        /// </summary>
+        public Func<BitbucketAuthenticatedContext, Task> OnAuthenticated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function that is invoked when the ReturnEndpoint method is invoked.
+        /// </summary>
+        public Func<BitbucketReturnEndpointContext, Task> OnReturnEndpoint { get; set; }
+
+        /// <summary>
+        /// Invoked whenever GitHub succesfully authenticates a user
+        /// </summary>
+        /// <param name="context">Contains information about the login session as well as the user <see cref="System.Security.Claims.ClaimsIdentity"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        public virtual Task Authenticated(BitbucketAuthenticatedContext context)
+        {
+            return OnAuthenticated(context);
+        }
+
+        /// <summary>
+        /// Invoked prior to the <see cref="System.Security.Claims.ClaimsIdentity"/> being saved in a local cookie and the browser being redirected to the originally requested URL.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        public virtual Task ReturnEndpoint(BitbucketReturnEndpointContext context)
+        {
+            return OnReturnEndpoint(context);
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/Provider/BitbucketReturnEndpointContext.cs
+++ b/Owin.Security.Providers/Bitbucket/Provider/BitbucketReturnEndpointContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Provider;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    /// <summary>
+    /// Provides context information to middleware providers.
+    /// </summary>
+    public class BitbucketReturnEndpointContext : ReturnEndpointContext
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context">OWIN environment</param>
+        /// <param name="ticket">The authentication ticket</param>
+        public BitbucketReturnEndpointContext(
+            IOwinContext context,
+            AuthenticationTicket ticket)
+            : base(context, ticket)
+        {
+        }
+    }
+}

--- a/Owin.Security.Providers/Bitbucket/Provider/IBitbucketAuthenticationProvider.cs
+++ b/Owin.Security.Providers/Bitbucket/Provider/IBitbucketAuthenticationProvider.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+
+namespace Owin.Security.Providers.Bitbucket
+{
+    /// <summary>
+    /// Specifies callback methods which the <see cref="BitbucketAuthenticationMiddleware"></see> invokes to enable developer control over the authentication process. />
+    /// </summary>
+    public interface IBitbucketAuthenticationProvider
+    {
+        /// <summary>
+        /// Invoked whenever GitHub succesfully authenticates a user
+        /// </summary>
+        /// <param name="context">Contains information about the login session as well as the user <see cref="System.Security.Claims.ClaimsIdentity"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        Task Authenticated(BitbucketAuthenticatedContext context);
+
+        /// <summary>
+        /// Invoked prior to the <see cref="System.Security.Claims.ClaimsIdentity"/> being saved in a local cookie and the browser being redirected to the originally requested URL.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        Task ReturnEndpoint(BitbucketReturnEndpointContext context);
+    }
+}

--- a/Owin.Security.Providers/Owin.Security.Providers.csproj
+++ b/Owin.Security.Providers/Owin.Security.Providers.csproj
@@ -161,6 +161,15 @@
     <Compile Include="Fitbit\Provider\FitbitAuthenticationProvider.cs" />
     <Compile Include="Fitbit\Provider\FitbitReturnEndpointContext.cs" />
     <Compile Include="Fitbit\Provider\IFitbitAuthenticationProvider.cs" />
+    <Compile Include="Bitbucket\Constants.cs" />
+    <Compile Include="Bitbucket\BitbucketAuthenticationExtensions.cs" />
+    <Compile Include="Bitbucket\BitbucketAuthenticationHandler.cs" />
+    <Compile Include="Bitbucket\BitbucketAuthenticationMiddleware.cs" />
+    <Compile Include="Bitbucket\BitbucketAuthenticationOptions.cs" />
+    <Compile Include="Bitbucket\Provider\BitbucketAuthenticatedContext.cs" />
+    <Compile Include="Bitbucket\Provider\BitbucketAuthenticationProvider.cs" />
+    <Compile Include="Bitbucket\Provider\BitbucketReturnEndpointContext.cs" />
+    <Compile Include="Bitbucket\Provider\IBitbucketAuthenticationProvider.cs" />
     <Compile Include="GitHub\Constants.cs" />
     <Compile Include="Gitter\Constants.cs" />
     <Compile Include="Gitter\GitterAuthenticationExtensions.cs" />


### PR DESCRIPTION
This is a pull request for issue #71. Bitbucket doesn't include a `state` parameter in the callback request, so I had to use cookies to persist the CSRF values (redirect uri, XsrfId, and correlation id). I'm not thrilled with using cookies, but since Bitbucket doesn't support it anyway, I guess it doesn't really matter (please correct me if I'm wrong).

Here's the Bitbucket documentation for their OAuth2 implementation that I used as a reference. 
https://developer.atlassian.com/bitbucket/concepts/oauth2.html
