### PR TITLE
if github scope contains user or user:email and context.Email is null

### DIFF
--- a/Owin.Security.Providers/GitHub/UserEmail.cs
+++ b/Owin.Security.Providers/GitHub/UserEmail.cs
@@ -1,0 +1,11 @@
+﻿namespace Owin.Security.Providers.GitHub
+{
+    public class UserEmail
+    {
+        public string Email { get; set; }
+
+        public bool Primary { get; set; }
+
+        public bool Verified { get; set; }
+    }
+}

--- a/Owin.Security.Providers/Owin.Security.Providers.csproj
+++ b/Owin.Security.Providers/Owin.Security.Providers.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Bitbucket\Provider\BitbucketReturnEndpointContext.cs" />
     <Compile Include="Bitbucket\Provider\IBitbucketAuthenticationProvider.cs" />
     <Compile Include="GitHub\Constants.cs" />
+    <Compile Include="GitHub\UserEmail.cs" />
     <Compile Include="Gitter\Constants.cs" />
     <Compile Include="Gitter\GitterAuthenticationExtensions.cs" />
     <Compile Include="Gitter\GitterAuthenticationHandler.cs" />


### PR DESCRIPTION
If GitHub scope contains `user` or `user:email` and `context.Email` is `null` make another request to `/user/emails` and attempt to get primary email address.
