### PR TITLE
Allow custom scopes for Salesforce

### DIFF
--- a/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationHandler.cs
@@ -187,7 +187,12 @@ namespace Owin.Security.Providers.Salesforce
             var state = Options.StateDataFormat.Protect(properties);
 
             var authorizationEndpoint =
-                $"{Options.Endpoints.AuthorizationEndpoint}?response_type={"code"}&client_id={Options.ClientId}&redirect_uri={HttpUtility.UrlEncode(redirectUri)}&display={"page"}&immediate={false}&state={Uri.EscapeDataString(state)}&scope={""}";
+                $"{Options.Endpoints.AuthorizationEndpoint}?response_type={"code"}&client_id={Options.ClientId}&redirect_uri={HttpUtility.UrlEncode(redirectUri)}&display={"page"}&immediate={false}&state={Uri.EscapeDataString(state)}";
+
+            if (Options.Scope.Count > 0)
+            {
+                authorizationEndpoint += $"&scope={string.Join(" ", Options.Scope)}";
+            }
 
             if (Options.Prompt != null)
             {

--- a/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationHandler.cs
@@ -189,7 +189,7 @@ namespace Owin.Security.Providers.Salesforce
             var authorizationEndpoint =
                 $"{Options.Endpoints.AuthorizationEndpoint}?response_type={"code"}&client_id={Options.ClientId}&redirect_uri={HttpUtility.UrlEncode(redirectUri)}&display={"page"}&immediate={false}&state={Uri.EscapeDataString(state)}";
 
-            if (Options.Scope.Count > 0)
+            if (Options.Scope != null && Options.Scope.Count > 0)
             {
                 authorizationEndpoint += $"&scope={string.Join(" ", Options.Scope)}";
             }


### PR DESCRIPTION
Pass list of scopes to Salesforce authorization endpoint to allow for customisation of scopes via existing configuration option.

We already have the `IList<string> SalesforceAuthenticationOptions.Scope` property but this is unused. It should be sent as a space separated list. See [Salesforce Scope Parameter Documentation](https://help.salesforce.com/apex/HTViewHelpDoc?id=remoteaccess_oauth_scopes.htm).
