### PR TITLE
add id to scope and mobile_phone to context

### DIFF
--- a/src/Owin.Security.Providers.Salesforce/Provider/SalesforceAuthenticatedContext.cs
+++ b/src/Owin.Security.Providers.Salesforce/Provider/SalesforceAuthenticatedContext.cs
@@ -40,6 +40,7 @@ namespace Owin.Security.Providers.Salesforce
             LastName = TryGetValue(user, "last_name");
             TimeZone = TryGetValue(user, "timezone");
             Active = TryGetValue(user, "active");
+            MobilePhone = TryGetValue(user, "mobile_phone");
         }
 
         /// <summary>
@@ -120,6 +121,11 @@ namespace Owin.Security.Providers.Salesforce
         /// Gets the user's Status
         /// </summary>
         public string Active { get; private set; }
+
+        /// <summary>
+        /// Gets the user's mobile phone number
+        /// </summary>
+        public string MobilePhone { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ClaimsIdentity"/> representing the user

--- a/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationOptions.cs
@@ -123,7 +123,7 @@ namespace Owin.Security.Providers.Salesforce
             Caption = Constants.DefaultAuthenticationType;
             CallbackPath = new PathString("/signin-salesforce");
             AuthenticationMode = AuthenticationMode.Passive;
-            Scope = new List<string>();
+            Scope = new List<string> { "id" };
             BackchannelTimeout = TimeSpan.FromSeconds(60);
             Endpoints = new SalesforceAuthenticationEndpoints
             {


### PR DESCRIPTION
. Add id to Scope for salesforce
. Add mobile_phone to context.
You will have to add this " context.Identity.AddClaim(new System.Security.Claims.Claim("urn:salesforce:mobile_phone", context.MobilePhone));" in OnAuthenticated when initializing UseSalesforceAuthentication.
