### PR TITLE
Provides email as a claim if available

### DIFF
--- a/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationHandler.cs
@@ -91,10 +91,18 @@ namespace Owin.Security.Providers.VKontakte
 
                 var response = await GetAuthorizationToken(authorizationCode);
                 var accessToken = (string)response["access_token"];
+                // email is optional and only the get auth token call returns the value
+                var email = (string)response["email"];
 
                 var user = await GetUser(response, accessToken);
 
                 var context = CreateAuthenticatedContext(user, accessToken, properties);
+
+                if (!string.IsNullOrEmpty(email))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.Email, email, XmlSchemaString,
+                        Options.AuthenticationType));
+                }
 
                 await Options.Provider.Authenticated(context);
 


### PR DESCRIPTION
Email is only returned by VK as the part of the response to https://oauth.vk.com/access_token.
(This is handled in GetAuthorizationToken)
The user get does not provide it.
Email is not mandatory, not all users have email.

Other solution would be to extend the context and pass the email to CreateAuthenticatedContext, I just wanted the smallest impact on the code.