### PR TITLE
Log exception when something goes wrong

### DIFF
--- a/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Salesforce/SalesforceAuthenticationHandler.cs
@@ -145,7 +145,7 @@ namespace Owin.Security.Providers.Salesforce
             }
             catch (Exception ex)
             {
-                _logger.WriteError(ex.Message);
+                _logger.WriteError(ex.Message, ex);
             }
             return new AuthenticationTicket(null, properties);
         }


### PR DESCRIPTION
Lots of details are lost when an exception occurs during login. We should log those so that we can determine which part of the method is throwing. 

I would also be keen to do a few method extracts as that one try block does a few different things, but not sure what your policy is on more substantial refactors?