### PR TITLE
The "v" parameter with version number becomes obligatory for all API …

### DIFF
--- a/src/Owin.Security.Providers.VKontakte/Provider/VKontakteAuthenticatedContext.cs
+++ b/src/Owin.Security.Providers.VKontakte/Provider/VKontakteAuthenticatedContext.cs
@@ -25,7 +25,7 @@ namespace Owin.Security.Providers.VKontakte.Provider
             User = user;
             AccessToken = accessToken;
 
-            Id = TryGetValue(user, "uid");
+            Id = TryGetValue(user, "id");
             var firstName = TryGetValue(user, "first_name");
             var lastName = TryGetValue(user, "last_name");
             UserName = firstName + " " + lastName;

--- a/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationHandler.cs
@@ -61,7 +61,7 @@ namespace Owin.Security.Providers.VKontakte
             var state = Options.StateDataFormat.Protect(properties);
 
             var authorizationEndpoint =
-                $"{Options.Endpoints.AuthorizationEndpoint}?client_id={Uri.EscapeDataString(Options.ClientId)}&redirect_uri={Uri.EscapeDataString(redirectUri)}&scope={Uri.EscapeDataString(scope)}&state={Uri.EscapeDataString(state)}&display={Uri.EscapeDataString(Options.Display)}";
+                $"{Options.Endpoints.AuthorizationEndpoint}?client_id={Uri.EscapeDataString(Options.ClientId)}&redirect_uri={Uri.EscapeDataString(redirectUri)}&scope={Uri.EscapeDataString(scope)}&state={Uri.EscapeDataString(state)}&display={Uri.EscapeDataString(Options.Display)}&v={Uri.EscapeDataString(Options.ApiVersion)}";
 
             Response.Redirect(authorizationEndpoint);
 
@@ -156,7 +156,7 @@ namespace Owin.Security.Providers.VKontakte
 
             // Get the VK user
             var userRequestUri = new Uri(
-                $"{Options.Endpoints.UserInfoEndpoint}?access_token={Uri.EscapeDataString(accessToken)}&user_id{userId}");
+                $"{Options.Endpoints.UserInfoEndpoint}?access_token={Uri.EscapeDataString(accessToken)}&user_id{userId}&v={Uri.EscapeDataString(Options.ApiVersion)}");
             var userResponse = await _httpClient.GetAsync(userRequestUri, Request.CallCancelled);
             userResponse.EnsureSuccessStatusCode();
 

--- a/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationOptions.cs
@@ -14,6 +14,7 @@ namespace Owin.Security.Providers.VKontakte
         private const string UserInfoEndpoint = "https://api.vk.com/method/users.get";
         private const string DefaultCallbackPath = "/signin-vkontakte";
         private const string DefaultDisplayMode = "page";
+	    private const string DefaultApiVersion = "5.73";
 
         /// <summary>
         ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
@@ -100,10 +101,18 @@ namespace Owin.Security.Providers.VKontakte
         /// </summary>
         public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
 
-        /// <summary>
-        ///     Initializes a new <see cref="VKontakteAuthenticationOptions" />
-        /// </summary>
-        public VKontakteAuthenticationOptions()
+	    /// <summary>
+	    /// Default API version. Required.
+	    /// </summary>
+	    /// <remarks>
+	    /// Defaults to 5.73
+	    /// </remarks>
+	    public string ApiVersion { get; set; }
+
+		/// <summary>
+		///     Initializes a new <see cref="VKontakteAuthenticationOptions" />
+		/// </summary>
+		public VKontakteAuthenticationOptions()
             : base(Constants.DefaultAuthenticationType)
         {
             Caption = Constants.DefaultAuthenticationType;
@@ -118,6 +127,7 @@ namespace Owin.Security.Providers.VKontakte
                 TokenEndpoint = TokenEndpoint,
                 UserInfoEndpoint = UserInfoEndpoint
             };
+	        ApiVersion = DefaultApiVersion;
         }
     }
 }


### PR DESCRIPTION
The "uid" parameter obsolete. Use "id" instead.
The "v" parameter with version number becomes obligatory for all API requests. An error will be returned if the parameter is not sent.
https://vk.com/dev/version_update