### PR TITLE
Fix "version is required" error, update for latest API usage

### DIFF
--- a/src/Owin.Security.Providers.VKontakte/Constants.cs
+++ b/src/Owin.Security.Providers.VKontakte/Constants.cs
@@ -3,5 +3,6 @@
     internal static class Constants
     {
         public const string DefaultAuthenticationType = "VKontakte";
+        public const string DefaultApiVersion = "5.73";
     }
 }

--- a/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationHandler.cs
@@ -61,7 +61,7 @@ namespace Owin.Security.Providers.VKontakte
             var state = Options.StateDataFormat.Protect(properties);
 
             var authorizationEndpoint =
-                $"{Options.Endpoints.AuthorizationEndpoint}?client_id={Uri.EscapeDataString(Options.ClientId)}&redirect_uri={Uri.EscapeDataString(redirectUri)}&scope={Uri.EscapeDataString(scope)}&state={Uri.EscapeDataString(state)}&display={Uri.EscapeDataString(Options.Display)}";
+                $"{Options.Endpoints.AuthorizationEndpoint}?client_id={Uri.EscapeDataString(Options.ClientId)}&redirect_uri={Uri.EscapeDataString(redirectUri)}&scope={Uri.EscapeDataString(scope)}&state={Uri.EscapeDataString(state)}&display={Uri.EscapeDataString(Options.Display)}&v={Options.ApiVersion}";
 
             Response.Redirect(authorizationEndpoint);
 
@@ -128,7 +128,7 @@ namespace Owin.Security.Providers.VKontakte
         private VKontakteAuthenticatedContext CreateAuthenticatedContext(JObject user, string accessToken,
             AuthenticationProperties properties)
         {
-            var context = new VKontakteAuthenticatedContext(Context, user, accessToken)
+            var context = new VKontakteAuthenticatedContext(Context, user, accessToken, Options.ApiVersion)
             {
                 Identity = new ClaimsIdentity(
                     Options.AuthenticationType,
@@ -156,7 +156,7 @@ namespace Owin.Security.Providers.VKontakte
 
             // Get the VK user
             var userRequestUri = new Uri(
-                $"{Options.Endpoints.UserInfoEndpoint}?access_token={Uri.EscapeDataString(accessToken)}&user_id{userId}");
+                $"{Options.Endpoints.UserInfoEndpoint}?access_token={Uri.EscapeDataString(accessToken)}&user_id={userId}&v={Options.ApiVersion}");
             var userResponse = await _httpClient.GetAsync(userRequestUri, Request.CallCancelled);
             userResponse.EnsureSuccessStatusCode();
 
@@ -175,7 +175,8 @@ namespace Owin.Security.Providers.VKontakte
                 {"code", authorizationCode},
                 {"redirect_uri", redirectUri},
                 {"client_id", Options.ClientId},
-                {"client_secret", Options.ClientSecret}
+                {"client_secret", Options.ClientSecret},
+                {"v", Options.ApiVersion}
             };
 
             // Request the token

--- a/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.VKontakte/VKontakteAuthenticationOptions.cs
@@ -101,6 +101,11 @@ namespace Owin.Security.Providers.VKontakte
         public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
 
         /// <summary>
+        ///     Gets or sets the VK API version
+        /// </summary>
+        public string ApiVersion { get; set; }
+
+        /// <summary>
         ///     Initializes a new <see cref="VKontakteAuthenticationOptions" />
         /// </summary>
         public VKontakteAuthenticationOptions()
@@ -112,6 +117,7 @@ namespace Owin.Security.Providers.VKontakte
             Display = DefaultDisplayMode;
             Scope = new List<string>();
             BackchannelTimeout = TimeSpan.FromSeconds(60);
+            ApiVersion = Constants.DefaultApiVersion;
             Endpoints = new VKontakteAuthenticationEndpoints
             {
                 AuthorizationEndpoint = AuthorizationEndPoint,


### PR DESCRIPTION
Hello everyone!
In latest VK API "version" parameter has required. Without this parameter VK return error when user info requested (Invalid request: v (version) is required). More info here: https://vk.com/dev/implicit_flow_user.
Also in version upper 5.0 has changed some names like uid -> id and so on (https://vk.com/dev/version5).
In this commit I have added new option "ApiVersion". By default api version is 5.73.