### PR TITLE
Update Steam OpenID Regex to handle HTTPS

### DIFF
--- a/src/Owin.Security.Providers.Steam/SteamAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Steam/SteamAuthenticationHandler.cs
@@ -10,7 +10,7 @@ namespace Owin.Security.Providers.Steam
 {
     internal sealed class SteamAuthenticationHandler : OpenIDAuthenticationHandlerBase<SteamAuthenticationOptions>
     {
-        private readonly Regex _accountIDRegex = new Regex(@"^http://steamcommunity\.com/openid/id/(7[0-9]{15,25})$", RegexOptions.Compiled);
+        private readonly Regex _accountIDRegex = new Regex(@"^https?://steamcommunity\.com/openid/id/(7[0-9]{15,25})$", RegexOptions.Compiled);
 
         private const string UserInfoUri = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key={0}&steamids={1}";
 


### PR DESCRIPTION
Steam have updated their implementation to return https URIs in claimedID (please see [this thread](https://www.reddit.com/r/Steam/comments/8a7gsu/steam_openid_broken_for_many_websites_fix_inside/)).

The current version of the `_accountIDRegex` does not handle this.

This change should fix this. Arguably, we should not include the option to accept http, as Steam have (seemingly) irrevocably changed this.

This should solve [Issue #234](https://github.com/TerribleDev/OwinOAuthProviders/issues/234).