### PR TITLE
Add a Request Prefix to Options so that we don't rely always on Request.Scheme or Request.Host.

### DIFF
--- a/src/Owin.Security.Providers.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Twitch/TwitchAuthenticationHandler.cs
@@ -60,8 +60,7 @@ namespace Owin.Security.Providers.Twitch
                     return new AuthenticationTicket(null, properties);
                 }
 
-                var requestPrefix = Request.Scheme + "://" + Request.Host;
-                var redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
+                var redirectUri = GetRequestPrefix() + Request.PathBase + Options.CallbackPath;
 
                 // Build up the body for the token request
                 var body = new List<KeyValuePair<string, string>>
@@ -146,9 +145,7 @@ namespace Owin.Security.Providers.Twitch
 
             if (challenge == null) return Task.FromResult<object>(null);
             var baseUri =
-                Request.Scheme +
-                Uri.SchemeDelimiter +
-                Request.Host +
+                GetRequestPrefix() +
                 Request.PathBase;
 
             var currentUri =
@@ -236,6 +233,13 @@ namespace Owin.Security.Providers.Twitch
             context.RequestCompleted();
 
             return context.IsRequestCompleted;
+        }
+
+        private string GetRequestPrefix()
+        {
+            return String.IsNullOrEmpty(Options.RequestPrefix)
+                       ? Options.RequestPrefix
+                       : Request.Scheme + Uri.SchemeDelimiter + Request.Host;
         }
     }
 }

--- a/src/Owin.Security.Providers.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Twitch/TwitchAuthenticationHandler.cs
@@ -237,7 +237,7 @@ namespace Owin.Security.Providers.Twitch
 
         private string GetRequestPrefix()
         {
-            return String.IsNullOrEmpty(Options.RequestPrefix)
+            return !String.IsNullOrEmpty(Options.RequestPrefix)
                        ? Options.RequestPrefix
                        : Request.Scheme + Uri.SchemeDelimiter + Request.Host;
         }

--- a/src/Owin.Security.Providers.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.Twitch/TwitchAuthenticationOptions.cs
@@ -126,6 +126,11 @@ namespace Owin.Security.Providers.Twitch
         public bool ForceVerify { get; set; }
 
         /// <summary>
+        ///     Gets or sets the Request prefix
+        /// </summary>
+        public string RequestPrefix { get; set; }
+
+        /// <summary>
         ///     Initializes a new <see cref="TwitchAuthenticationOptions" />
         /// </summary>
         public TwitchAuthenticationOptions()


### PR DESCRIPTION
We're developing an application that relies on how this variable is being used internally and would like it to be an Option for those who want to set it beforehand.

The issue at the moment is that Request.Scheme and Request.Host are not exactly following what is standard and we end up with an incorrect "redirect_uri" on the query string that is sent to the Twitch API.

This change will only add a small option to those that need to change this parameter.