### PR TITLE
Discord authenticated context mapping

### DIFF
--- a/src/Owin.Security.Providers.Discord/Provider/DiscordAuthenticatedContext.cs
+++ b/src/Owin.Security.Providers.Discord/Provider/DiscordAuthenticatedContext.cs
@@ -39,7 +39,7 @@ namespace Owin.Security.Providers.Discord.Provider
             Discriminator = TryGetValue(user, "discriminator");
             Avatar = TryGetValue(user, "avatar");
             Email = TryGetValue(user, "email");
-            Verified = TryGetValue(user, "verified") == "true";
+            Verified = TryGetValue(user, "verified").ToLowerInvariant() == "true";
         }
 
         public string RefreshToken { get; set; }


### PR DESCRIPTION
When trying to map the verified property on the user json object this always resulted in false because discord serializes true as "True" added a tolowerinvariant to counter this.